### PR TITLE
Fixes and additions.

### DIFF
--- a/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/DreamScreenBindingConstants.java
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/DreamScreenBindingConstants.java
@@ -45,7 +45,8 @@ public class DreamScreenBindingConstants {
     public static final int PRODUCT_ID_HD = 1;
     public static final int PRODUCT_ID_4K = 2;
     public static final int PRODUCT_ID_SIDEKICK = 3;
-    public static final int PRODUCT_ID_CONNECT = 6;
+    public static final int PRODUCT_ID_CONNECT = 4;
+    public static final int PRODUCT_ID_SOLO = 7;
 
     // List of all Channel ids
     public static final String CHANNEL_POWER = "power";

--- a/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/DreamScreenBindingConstants.java
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/DreamScreenBindingConstants.java
@@ -54,6 +54,8 @@ public class DreamScreenBindingConstants {
     public static final String CHANNEL_SCENE = "scene";
     public static final String CHANNEL_INPUT = "input";
     public static final String CHANNEL_COLOR = "color";
+    public static final String CHANNEL_SATURATION = "saturation";
+    public static final String CHANNEL_BRIGHTNESS = "brightness";
 
     // Mode values
     public static final String MODE_VIDEO = "video";

--- a/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/handler/DreamScreenBaseHandler.java
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/handler/DreamScreenBaseHandler.java
@@ -84,6 +84,8 @@ public abstract class DreamScreenBaseHandler extends BaseThingHandler {
     private byte ambientScene = RANDOM_COLOR.ambientScene;
     private @Nullable DreamScreenScene newScene = null;
     private HSBType color = HSBType.WHITE;
+    private HSBType saturation = HSBType.WHITE;
+    private int brightness = 100;
     private boolean isOnline = false;
 
     public DreamScreenBaseHandler(DreamScreenServer server, final Thing thing) {
@@ -222,6 +224,9 @@ public abstract class DreamScreenBaseHandler extends BaseThingHandler {
         modeRefresh(msg.getMode());
         colorRefresh(msg.getRed(), msg.getGreen(), msg.getBlue());
         this.ambientScene = msg.getScene(); // ambientSceneRefresh(msg.getScene());
+        this.brightness = msg.getBrightness();
+        updateState(CHANNEL_BRIGHTNESS, new DecimalType(this.brightness));
+        saturationRefresh(msg.getSaturation());
         read(new AmbientModeTypeMessage(this.group, this.ambientModeType));
         return true;
     }
@@ -369,6 +374,11 @@ public abstract class DreamScreenBaseHandler extends BaseThingHandler {
     private void colorRefresh(final byte red, final byte green, final byte blue) {
         this.color = HSBType.fromRGB(red & 0xFF, green & 0xFF, blue & 0xFF);
         updateState(CHANNEL_COLOR, this.color);
+    }
+
+    private void saturationRefresh(HSBType sat) {
+        this.saturation = sat;
+        updateState(CHANNEL_SATURATION, sat);
     }
 
     protected void read(final DreamScreenMessage msg) {

--- a/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/handler/DreamScreenSoloHandler.java
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/handler/DreamScreenSoloHandler.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.dreamscreen.internal.handler;
+
+import static org.openhab.binding.dreamscreen.internal.DreamScreenBindingConstants.PRODUCT_ID_SOLO;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.openhab.binding.dreamscreen.internal.DreamScreenServer;
+import org.openhab.binding.dreamscreen.internal.message.RefreshTvMessage;
+
+/**
+ * The {@link DreamScreenSoloHandler} is the Thing Handler for the DreamScreen HD device.
+ *
+ * @author Bruce Brouwer - Initial contribution
+ */
+
+@NonNullByDefault
+public class DreamScreenSoloHandler extends DreamScreenBaseTvHandler {
+    public final static byte PRODUCT_ID = (byte) PRODUCT_ID_SOLO;
+
+    public DreamScreenSoloHandler(DreamScreenServer server, Thing thing,
+            DreamScreenInputDescriptionProvider descriptionProvider) {
+        super(server, thing, descriptionProvider);
+    }
+
+    @Override
+    protected boolean refreshTvMsg(final RefreshTvMessage msg) {
+        if (msg.getProductId() == PRODUCT_ID) {
+            return super.refreshTvMsg(msg);
+        }
+        return false;
+    }
+}

--- a/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/AmbientModeTypeMessage.java
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/AmbientModeTypeMessage.java
@@ -26,16 +26,16 @@ public class AmbientModeTypeMessage extends DreamScreenMessage {
     static final byte COMMAND_UPPER = 0x03;
     static final byte COMMAND_LOWER = 0x08;
 
-    protected AmbientModeTypeMessage(final byte[] data, final int off) {
-        super(data, off);
+    protected AmbientModeTypeMessage(final byte[] data) {
+        super(data);
     }
 
     public AmbientModeTypeMessage(final byte group, final byte ambientModeType) {
         super(group, COMMAND_UPPER, COMMAND_LOWER, new byte[] { ambientModeType });
     }
 
-    static boolean matches(final byte[] data, final int off) {
-        return matches(data, off, COMMAND_UPPER, COMMAND_LOWER);
+    static boolean matches(final byte[] data) {
+        return matches(data, COMMAND_UPPER, COMMAND_LOWER);
     }
 
     public byte getAmbientModeType() {

--- a/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/ColorMessage.java
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/ColorMessage.java
@@ -24,16 +24,16 @@ public class ColorMessage extends DreamScreenMessage {
     static final byte COMMAND_UPPER = 0x03;
     static final byte COMMAND_LOWER = 0x05;
 
-    protected ColorMessage(final byte[] data, final int off) {
-        super(data, off);
+    protected ColorMessage(final byte[] data) {
+        super(data);
     }
 
     public ColorMessage(byte group, byte red, byte green, byte blue) {
         super(group, COMMAND_UPPER, COMMAND_LOWER, new byte[] { red, green, blue });
     }
 
-    static boolean matches(final byte[] data, final int off) {
-        return matches(data, off, COMMAND_UPPER, COMMAND_LOWER);
+    static boolean matches(final byte[] data) {
+        return matches(data, COMMAND_UPPER, COMMAND_LOWER);
     }
 
     public byte getRed() {

--- a/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/DreamScreenMessage.java
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/DreamScreenMessage.java
@@ -1,13 +1,13 @@
 /**
  * Copyright (c) 2010-2020 Contributors to the openHAB project
- *
+ * <p>
  * See the NOTICE file(s) distributed with this work for additional
  * information.
- *
+ * <p>
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0
- *
+ * <p>
  * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.binding.dreamscreen.internal.message;
@@ -17,7 +17,6 @@ import java.net.InetAddress;
 import java.nio.ByteBuffer;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.smarthome.core.types.RefreshType;
 
 /**
  * The {@link DreamScreenMessage} implements general message handling.

--- a/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/DreamScreenMessage.java
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/DreamScreenMessage.java
@@ -32,11 +32,13 @@ public abstract class DreamScreenMessage {
     protected final int payloadLen;
     protected int deviceType;
 
+    static final byte MAGIC_BYTE = (byte) 0xFC;
+
     public static DreamScreenMessage fromPacket(final DatagramPacket packet) throws DreamScreenMessageInvalid {
         final int len = packet.getLength();
         final byte[] data = packet.getData();
         final int msgLen;
-        if (len > 6 && data[0] == (byte) 0xFC) {
+        if (len > 6 && data[0] == MAGIC_BYTE) {
             msgLen = data[1] & 0xFF;
             if (msgLen + 2 > len) {
                 throw new DreamScreenMessageInvalid("Invalid length");

--- a/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/DreamScreenMessage.java
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/DreamScreenMessage.java
@@ -31,6 +31,7 @@ public abstract class DreamScreenMessage {
     private final byte commandLower;
     protected final ByteBuffer payload;
     protected final int payloadLen;
+    protected int deviceType;
 
     public static DreamScreenMessage fromPacket(final DatagramPacket packet) throws DreamScreenMessageInvalid {
         final int len = packet.getLength();

--- a/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/InputMessage.java
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/InputMessage.java
@@ -24,16 +24,16 @@ public class InputMessage extends DreamScreenMessage {
     static final byte COMMAND_UPPER = 0x03;
     static final byte COMMAND_LOWER = 0x20;
 
-    protected InputMessage(final byte[] data, final int off) {
-        super(data, off);
+    protected InputMessage(final byte[] data) {
+        super(data);
     }
 
     public InputMessage(byte group, byte input) {
         super(group, COMMAND_UPPER, COMMAND_LOWER, new byte[] { input });
     }
 
-    static boolean matches(final byte[] data, final int off) {
-        return matches(data, off, COMMAND_UPPER, COMMAND_LOWER);
+    static boolean matches(final byte[] data) {
+        return matches(data, COMMAND_UPPER, COMMAND_LOWER);
     }
 
     public byte getInput() {

--- a/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/ModeMessage.java
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/ModeMessage.java
@@ -25,16 +25,16 @@ public class ModeMessage extends DreamScreenMessage {
     static final byte COMMAND_UPPER = 0x03;
     static final byte COMMAND_LOWER = 0x01;
 
-    protected ModeMessage(final byte[] data, final int off) {
-        super(data, off);
+    protected ModeMessage(final byte[] data) {
+        super(data);
     }
 
     public ModeMessage(byte group, byte mode) {
         super(group, COMMAND_UPPER, COMMAND_LOWER, new byte[] { mode });
     }
 
-    static boolean matches(final byte[] data, final int off) {
-        return matches(data, off, COMMAND_UPPER, COMMAND_LOWER);
+    static boolean matches(final byte[] data) {
+        return matches(data, COMMAND_UPPER, COMMAND_LOWER);
     }
 
     public byte getMode() {

--- a/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/RefreshMessage.java
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/RefreshMessage.java
@@ -17,6 +17,7 @@ import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.library.types.HSBType;
 
 /**
  * {@link RefreshMessage} handles the Refresh Message.
@@ -84,11 +85,16 @@ public class RefreshMessage extends DreamScreenMessage {
         return this.payload.get(colorInt + 2);
     }
 
-    public byte[] getColor() { return new byte[]{this.payload.get(colorInt), this.payload.get(colorInt + 1), this.payload.get(colorInt + 2)}; }
+    public byte getBrightness() {
+        return this.payload.get(brightnessInt);
+    }
 
-    public byte getBrightness() { return this.payload.get(brightnessInt); }
-
-    public byte[] getSaturation() { return new byte[]{this.payload.get(saturationInt), this.payload.get(saturationInt + 1), this.payload.get(saturationInt + 2)}; }
+    public HSBType getSaturation() {
+        int r = this.payload.get(saturationInt);
+        int g = this.payload.get(saturationInt + 1);
+        int b = this.payload.get(saturationInt + 2);
+        return HSBType.fromRGB(r & 0xFF, g & 0xFF, b & 0xFF);
+    }
 
     public byte getProductId() {
         return this.payload.get(this.payloadLen - 1);

--- a/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/RefreshMessage.java
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/RefreshMessage.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.dreamscreen.internal.message;
 
+import static org.openhab.binding.dreamscreen.internal.DreamScreenBindingConstants.*;
+
 import java.net.DatagramPacket;
 import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
@@ -42,7 +44,6 @@ public class RefreshMessage extends DreamScreenMessage {
     private int n1Int = 75;
     private int n2Int = 91;
     private int n3Int = 107;
-
 
     public RefreshMessage() {
         super((byte) 0xFF, COMMAND_UPPER, COMMAND_LOWER, new byte[0]);
@@ -112,9 +113,9 @@ public class RefreshMessage extends DreamScreenMessage {
 
     private void refreshType() {
         switch (super.deviceType) {
-            case 1:
-            case 2:
-            case 7:
+            case PRODUCT_ID_HD:
+            case PRODUCT_ID_4K:
+            case PRODUCT_ID_SOLO:
                 groupInt = 32;
                 modeInt = 33;
                 brightnessInt = 34;
@@ -126,8 +127,8 @@ public class RefreshMessage extends DreamScreenMessage {
                 n2Int = 91;
                 n3Int = 107;
                 break;
-            case 3:
-            case 4:
+            case PRODUCT_ID_SIDEKICK:
+            case PRODUCT_ID_CONNECT:
                 groupInt = 32;
                 modeInt = 33;
                 brightnessInt = 34;

--- a/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/RefreshMessage.java
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/RefreshMessage.java
@@ -33,17 +33,17 @@ public class RefreshMessage extends DreamScreenMessage {
 
     // Set integers so we know which bytes to pull based on device
 
-    private int groupInt = 32;
-    private int modeInt = 33;
-    private int brightnessInt = 34;
-    private int colorInt = 40;
-    private int saturationInt = 43;
-    private int ambientSceneInt = 62;
+    static int OFF_GROUP = 32;
+    static int OFF_MODE = 33;
+    static int OFF_BRIGHTNESS = 34;
+    static int OFF_COLOR = 40;
+    static int OFF_SATURATION = 43;
+    static int OFF_AMBIENT_SCENE = 62;
     // Throwback from original stuff, might not be needed
-    private int inputInt = 73;
-    private int n1Int = 75;
-    private int n2Int = 91;
-    private int n3Int = 107;
+    static int OFF_INPUT_ID = 73;
+    static int OFF_INPUT_N1 = 75;
+    static int OFF_INPUT_N2 = 91;
+    static int OFF_INPUT_N3 = 107;
 
     public RefreshMessage() {
         super((byte) 0xFF, COMMAND_UPPER, COMMAND_LOWER, new byte[0]);
@@ -59,7 +59,7 @@ public class RefreshMessage extends DreamScreenMessage {
     }
 
     public byte getGroup() {
-        return this.payload.get(groupInt);
+        return this.payload.get(OFF_GROUP);
     }
 
     public String getName() {
@@ -67,33 +67,33 @@ public class RefreshMessage extends DreamScreenMessage {
     }
 
     public byte getMode() {
-        return this.payload.get(modeInt);
+        return this.payload.get(OFF_MODE);
     }
 
     public byte getScene() {
-        return this.payload.get(ambientSceneInt);
+        return this.payload.get(OFF_AMBIENT_SCENE);
     }
 
     public byte getRed() {
-        return this.payload.get(colorInt);
+        return this.payload.get(OFF_COLOR);
     }
 
     public byte getGreen() {
-        return this.payload.get(colorInt + 1);
+        return this.payload.get(OFF_COLOR + 1);
     }
 
     public byte getBlue() {
-        return this.payload.get(colorInt + 2);
+        return this.payload.get(OFF_COLOR + 2);
     }
 
     public byte getBrightness() {
-        return this.payload.get(brightnessInt);
+        return this.payload.get(OFF_BRIGHTNESS);
     }
 
     public HSBType getSaturation() {
-        int r = this.payload.get(saturationInt);
-        int g = this.payload.get(saturationInt + 1);
-        int b = this.payload.get(saturationInt + 2);
+        int r = this.payload.get(OFF_SATURATION);
+        int g = this.payload.get(OFF_SATURATION + 1);
+        int b = this.payload.get(OFF_SATURATION + 2);
         return HSBType.fromRGB(r & 0xFF, g & 0xFF, b & 0xFF);
     }
 
@@ -116,29 +116,29 @@ public class RefreshMessage extends DreamScreenMessage {
             case PRODUCT_ID_HD:
             case PRODUCT_ID_4K:
             case PRODUCT_ID_SOLO:
-                groupInt = 32;
-                modeInt = 33;
-                brightnessInt = 34;
-                colorInt = 40;
-                saturationInt = 43;
-                ambientSceneInt = 62;
-                inputInt = 73;
-                n1Int = 75;
-                n2Int = 91;
-                n3Int = 107;
+                OFF_GROUP = 32;
+                OFF_MODE = 33;
+                OFF_BRIGHTNESS = 34;
+                OFF_COLOR = 40;
+                OFF_SATURATION = 43;
+                OFF_AMBIENT_SCENE = 62;
+                OFF_INPUT_ID = 73;
+                OFF_INPUT_N1 = 75;
+                OFF_INPUT_N2 = 91;
+                OFF_INPUT_N3 = 107;
                 break;
             case PRODUCT_ID_SIDEKICK:
             case PRODUCT_ID_CONNECT:
-                groupInt = 32;
-                modeInt = 33;
-                brightnessInt = 34;
-                colorInt = 35;
-                saturationInt = 38;
-                ambientSceneInt = 60;
-                inputInt = -1;
-                n1Int = -1;
-                n2Int = -1;
-                n3Int = -1;
+                OFF_GROUP = 32;
+                OFF_MODE = 33;
+                OFF_BRIGHTNESS = 34;
+                OFF_COLOR = 35;
+                OFF_SATURATION = 38;
+                OFF_AMBIENT_SCENE = 60;
+                OFF_INPUT_ID = -1;
+                OFF_INPUT_N1 = -1;
+                OFF_INPUT_N2 = -1;
+                OFF_INPUT_N3 = -1;
                 break;
         }
     }

--- a/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/RefreshMessage.java
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/RefreshMessage.java
@@ -28,6 +28,20 @@ public class RefreshMessage extends DreamScreenMessage {
     static final byte COMMAND_UPPER = 0x01;
     static final byte COMMAND_LOWER = 0x0A;
 
+    // Set integers so we know which bytes to pull based on device
+
+    private int groupInt = 32;
+    private int modeInt = 33;
+    private int brightnessInt = 34;
+    private int colorInt = 40;
+    private int saturationInt = 43;
+    private int ambientSceneInt = 62;
+    // Throwback from original stuff, might not be needed
+    private int inputInt = 73;
+    private int n1Int = 75;
+    private int n2Int = 91;
+    private int n3Int = 107;
+
 
     public RefreshMessage() {
         super((byte) 0xFF, COMMAND_UPPER, COMMAND_LOWER, new byte[0]);
@@ -43,7 +57,7 @@ public class RefreshMessage extends DreamScreenMessage {
     }
 
     public byte getGroup() {
-        return this.payload.get(32);
+        return this.payload.get(groupInt);
     }
 
     public String getName() {
@@ -51,24 +65,30 @@ public class RefreshMessage extends DreamScreenMessage {
     }
 
     public byte getMode() {
-        return this.payload.get(33);
+        return this.payload.get(modeInt);
     }
 
     public byte getScene() {
-        return this.payload.get(62);
+        return this.payload.get(ambientSceneInt);
     }
 
     public byte getRed() {
-        return this.payload.get(40);
+        return this.payload.get(colorInt);
     }
 
     public byte getGreen() {
-        return this.payload.get(41);
+        return this.payload.get(colorInt + 1);
     }
 
     public byte getBlue() {
-        return this.payload.get(42);
+        return this.payload.get(colorInt + 2);
     }
+
+    public byte[] getColor() { return new byte[]{this.payload.get(colorInt), this.payload.get(colorInt + 1), this.payload.get(colorInt + 2)}; }
+
+    public byte getBrightness() { return this.payload.get(brightnessInt); }
+
+    public byte[] getSaturation() { return new byte[]{this.payload.get(saturationInt), this.payload.get(saturationInt + 1), this.payload.get(saturationInt + 2)}; }
 
     public byte getProductId() {
         return this.payload.get(this.payloadLen - 1);
@@ -82,5 +102,37 @@ public class RefreshMessage extends DreamScreenMessage {
     @Override
     public String toString() {
         return "Refresh";
+    }
+
+    private void refreshType() {
+        switch (super.deviceType) {
+            case 1:
+            case 2:
+            case 7:
+                groupInt = 32;
+                modeInt = 33;
+                brightnessInt = 34;
+                colorInt = 40;
+                saturationInt = 43;
+                ambientSceneInt = 62;
+                inputInt = 73;
+                n1Int = 75;
+                n2Int = 91;
+                n3Int = 107;
+                break;
+            case 3:
+            case 4:
+                groupInt = 32;
+                modeInt = 33;
+                brightnessInt = 34;
+                colorInt = 35;
+                saturationInt = 38;
+                ambientSceneInt = 60;
+                inputInt = -1;
+                n1Int = -1;
+                n2Int = -1;
+                n3Int = -1;
+                break;
+        }
     }
 }

--- a/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/RefreshMessage.java
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/RefreshMessage.java
@@ -28,16 +28,18 @@ public class RefreshMessage extends DreamScreenMessage {
     static final byte COMMAND_UPPER = 0x01;
     static final byte COMMAND_LOWER = 0x0A;
 
-    protected RefreshMessage(final byte[] data, final int off) {
-        super(data, off);
-    }
 
     public RefreshMessage() {
         super((byte) 0xFF, COMMAND_UPPER, COMMAND_LOWER, new byte[0]);
     }
 
-    static boolean matches(final byte[] data, final int off) {
-        return matches(data, off, COMMAND_UPPER, COMMAND_LOWER);
+    public RefreshMessage(final byte[] data) {
+        super(data);
+        refreshType();
+    }
+
+    static boolean matches(final byte[] data) {
+        return matches(data, COMMAND_UPPER, COMMAND_LOWER);
     }
 
     public byte getGroup() {

--- a/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/RefreshTvMessage.java
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/RefreshTvMessage.java
@@ -17,6 +17,7 @@ import java.nio.charset.StandardCharsets;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.dreamscreen.internal.handler.DreamScreen4kHandler;
 import org.openhab.binding.dreamscreen.internal.handler.DreamScreenHdHandler;
+import org.openhab.binding.dreamscreen.internal.handler.DreamScreenSoloHandler;
 
 /**
  * {@link RefreshTvMessage} handles the Refresh TV Message.
@@ -34,7 +35,7 @@ public class RefreshTvMessage extends RefreshMessage {
         if (RefreshMessage.matches(data)) {
             final int msgLen = data[1] & 0xFF;
             final byte productId = data[msgLen];
-            return productId == DreamScreenHdHandler.PRODUCT_ID || productId == DreamScreen4kHandler.PRODUCT_ID;
+            return productId == DreamScreenHdHandler.PRODUCT_ID || productId == DreamScreen4kHandler.PRODUCT_ID || productId == DreamScreenSoloHandler.PRODUCT_ID;
         }
         return false;
     }

--- a/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/RefreshTvMessage.java
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/RefreshTvMessage.java
@@ -26,14 +26,14 @@ import org.openhab.binding.dreamscreen.internal.handler.DreamScreenHdHandler;
 @NonNullByDefault
 public class RefreshTvMessage extends RefreshMessage {
 
-    protected RefreshTvMessage(final byte[] data, final int off) {
-        super(data, off);
+    protected RefreshTvMessage(final byte[] data) {
+        super(data);
     }
 
-    static boolean matches(final byte[] data, final int off) {
-        if (RefreshMessage.matches(data, off)) {
-            final int msgLen = data[off + 1] & 0xFF;
-            final byte productId = data[off + msgLen];
+    static boolean matches(final byte[] data) {
+        if (RefreshMessage.matches(data)) {
+            final int msgLen = data[1] & 0xFF;
+            final byte productId = data[msgLen];
             return productId == DreamScreenHdHandler.PRODUCT_ID || productId == DreamScreen4kHandler.PRODUCT_ID;
         }
         return false;

--- a/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/SceneMessage.java
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/SceneMessage.java
@@ -25,16 +25,16 @@ public class SceneMessage extends DreamScreenMessage {
     static final byte COMMAND_UPPER = 0x03;
     static final byte COMMAND_LOWER = 0x0D;
 
-    protected SceneMessage(final byte[] data, final int off) {
-        super(data, off);
+    protected SceneMessage(final byte[] data) {
+        super(data);
     }
 
     public SceneMessage(byte group, byte ambientScene) {
         super(group, COMMAND_UPPER, COMMAND_LOWER, new byte[] { ambientScene });
     }
 
-    static boolean matches(final byte[] data, final int off) {
-        return matches(data, off, COMMAND_UPPER, COMMAND_LOWER);
+    static boolean matches(final byte[] data) {
+        return matches(data, COMMAND_UPPER, COMMAND_LOWER);
     }
 
     public byte getScene() {

--- a/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/SerialNumberMessage.java
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/SerialNumberMessage.java
@@ -27,12 +27,12 @@ public class SerialNumberMessage extends DreamScreenMessage {
     private static final byte COMMAND_UPPER = 0x01;
     private static final byte COMMAND_LOWER = 0x03;
 
-    protected SerialNumberMessage(final byte[] data, final int off) {
-        super(data, off);
+    protected SerialNumberMessage(final byte[] data) {
+        super(data);
     }
 
-    static boolean matches(final byte[] data, final int off) {
-        return matches(data, off, COMMAND_UPPER, COMMAND_LOWER);
+    static boolean matches(final byte[] data) {
+        return matches(data, COMMAND_UPPER, COMMAND_LOWER);
     }
 
     public int getSerialNumber() {

--- a/bundles/org.openhab.binding.dreamscreen/src/main/resources/ESH-INF/config/config.xml
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/resources/ESH-INF/config/config.xml
@@ -10,10 +10,10 @@
 			<description>The serial number of the DreamScreen device</description>
 		</parameter>
 
-        <parameter name="groupId" type="text">
-            <label>Group Id</label>
-            <description>Logical group Id to control multiple devices at once</description>
-        </parameter>
+		<parameter name="groupId" type="text">
+			<label>Group Id</label>
+			<description>Logical group Id to control multiple devices at once</description>
+		</parameter>
 	</config-description>
 
 </config-description:config-descriptions>

--- a/bundles/org.openhab.binding.dreamscreen/src/main/resources/ESH-INF/thing/4k.xml
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/resources/ESH-INF/thing/4k.xml
@@ -14,6 +14,8 @@
 			<channel id="mode" typeId="mode"/>
 			<channel id="scene" typeId="scene"/>
 			<channel id="color" typeId="color"/>
+			<channel id="saturation" typeId="saturation"/>
+			<channel id="brightness" typeId="brightness"/>
 		</channels>
 
 		<representation-property>serialNumber</representation-property>

--- a/bundles/org.openhab.binding.dreamscreen/src/main/resources/ESH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/resources/ESH-INF/thing/channels.xml
@@ -62,4 +62,17 @@
 		<description>Select the active color to use with the Color scene</description>
 	</channel-type>
 
+	<channel-type id="saturation">
+		<item-type>Color</item-type>
+		<label>Saturation</label>
+		<description>Control the saturation of your DS device</description>
+	</channel-type>
+
+	<channel-type id="brightness">
+		<item-type>Brightness</item-type>
+		<label>Brightness</label>
+		<description>Select the device brightness</description>
+		<state min="0" max="100" step="1.0" readOnly="false"/>
+	</channel-type>
+
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.dreamscreen/src/main/resources/ESH-INF/thing/connect.xml
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/resources/ESH-INF/thing/connect.xml
@@ -14,6 +14,8 @@
 			<channel id="mode" typeId="mode"/>
 			<channel id="scene" typeId="scene"/>
 			<channel id="color" typeId="color"/>
+			<channel id="saturation" typeId="saturation"/>
+			<channel id="brightness" typeId="brightness"/>
 		</channels>
 
 		<representation-property>serialNumber</representation-property>

--- a/bundles/org.openhab.binding.dreamscreen/src/main/resources/ESH-INF/thing/connect.xml
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/resources/ESH-INF/thing/connect.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <thing:thing-descriptions bindingId="dreamscreen"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
-    xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
-    <thing-type id="connect">
-        <label>DreamScreen Connect</label>
-        <description>Controls the DreamScreen Connect</description>
+	<thing-type id="connect">
+		<label>DreamScreen Connect</label>
+		<description>Controls the DreamScreen Connect</description>
 
-        <channels>
-            <channel id="power" typeId="power"/>
-            <channel id="input" typeId="input"/>
-            <channel id="mode" typeId="mode"/>
-            <channel id="scene" typeId="scene"/>
-            <channel id="color" typeId="color"/>
-        </channels>
+		<channels>
+			<channel id="power" typeId="power"/>
+			<channel id="input" typeId="input"/>
+			<channel id="mode" typeId="mode"/>
+			<channel id="scene" typeId="scene"/>
+			<channel id="color" typeId="color"/>
+		</channels>
 
-        <representation-property>serialNumber</representation-property>
-        <config-description-ref uri="thing-type:dreamscreen:serialnumber"/>
+		<representation-property>serialNumber</representation-property>
+		<config-description-ref uri="thing-type:dreamscreen:serialnumber"/>
 
-    </thing-type>
+	</thing-type>
 
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.dreamscreen/src/main/resources/ESH-INF/thing/hd.xml
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/resources/ESH-INF/thing/hd.xml
@@ -14,6 +14,8 @@
 			<channel id="mode" typeId="mode"/>
 			<channel id="scene" typeId="scene"/>
 			<channel id="color" typeId="color"/>
+			<channel id="saturation" typeId="saturation"/>
+			<channel id="brightness" typeId="brightness"/>
 		</channels>
 
 		<representation-property>serialNumber</representation-property>

--- a/bundles/org.openhab.binding.dreamscreen/src/main/resources/ESH-INF/thing/sidekick.xml
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/resources/ESH-INF/thing/sidekick.xml
@@ -13,6 +13,8 @@
 			<channel id="mode" typeId="mode"/>
 			<channel id="scene" typeId="scene"/>
 			<channel id="color" typeId="color"/>
+			<channel id="saturation" typeId="saturation"/>
+			<channel id="brightness" typeId="brightness"/>
 		</channels>
 
 		<representation-property>serialNumber</representation-property>

--- a/bundles/org.openhab.binding.dreamscreen/src/main/resources/ESH-INF/thing/solo.xml
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/resources/ESH-INF/thing/solo.xml
@@ -10,10 +10,11 @@
 
 		<channels>
 			<channel id="power" typeId="power"/>
-			<channel id="input" typeId="input"/>
 			<channel id="mode" typeId="mode"/>
 			<channel id="scene" typeId="scene"/>
 			<channel id="color" typeId="color"/>
+			<channel id="saturation" typeId="saturation"/>
+			<channel id="brightness" typeId="brightness"/>
 		</channels>
 
 		<representation-property>serialNumber</representation-property>

--- a/bundles/org.openhab.binding.dreamscreen/src/main/resources/ESH-INF/thing/solo.xml
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/resources/ESH-INF/thing/solo.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="dreamscreen"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="solo">
+		<label>DreamScreen Solo</label>
+		<description>Controls the DreamScreen Solo</description>
+
+		<channels>
+			<channel id="power" typeId="power"/>
+			<channel id="input" typeId="input"/>
+			<channel id="mode" typeId="mode"/>
+			<channel id="scene" typeId="scene"/>
+			<channel id="color" typeId="color"/>
+		</channels>
+
+		<representation-property>serialNumber</representation-property>
+		<config-description-ref uri="thing-type:dreamscreen:serialnumber"/>
+
+	</thing-type>
+
+
+</thing:thing-descriptions>


### PR DESCRIPTION
Set correct device ID for connect, add solo definitions.
Remove unnecessary passing of "offset" value around code.
Decode device ID on message receipt and dynamically load proper byte offsets to decode state messages.
Add initial calls for color/saturation/brightness setters getters.