### PR TITLE
Dreamscreen snapshot

### DIFF
--- a/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/DreamScreenBindingConstants.java
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/DreamScreenBindingConstants.java
@@ -58,6 +58,7 @@ public class DreamScreenBindingConstants {
     public static final String CHANNEL_BRIGHTNESS = "brightness";
 
     // Mode values
+    public static final String MODE_SLEEP = "sleep";
     public static final String MODE_VIDEO = "video";
     public static final String MODE_MUSIC = "music";
     public static final String MODE_AMBIENT = "ambient";

--- a/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/DreamScreenMessage.java
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/DreamScreenMessage.java
@@ -1,13 +1,13 @@
 /**
  * Copyright (c) 2010-2020 Contributors to the openHAB project
- * <p>
+ *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
- * <p>
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0
- * <p>
+ *
  * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.binding.dreamscreen.internal.message;

--- a/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/RefreshMessage.java
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/RefreshMessage.java
@@ -32,7 +32,6 @@ public class RefreshMessage extends DreamScreenMessage {
     static final byte COMMAND_LOWER = 0x0A;
 
     // Set integers so we know which bytes to pull based on device
-
     static int OFF_GROUP = 32;
     static int OFF_MODE = 33;
     static int OFF_BRIGHTNESS = 34;
@@ -71,7 +70,11 @@ public class RefreshMessage extends DreamScreenMessage {
     }
 
     public byte getScene() {
-        return this.payload.get(OFF_AMBIENT_SCENE);
+        if (this.payloadLen >= 60) {
+            return this.payload.get(OFF_AMBIENT_SCENE);
+        } else {
+            return 0;
+        }
     }
 
     public byte getRed() {

--- a/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/RefreshTvMessage.java
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/message/RefreshTvMessage.java
@@ -35,7 +35,8 @@ public class RefreshTvMessage extends RefreshMessage {
         if (RefreshMessage.matches(data)) {
             final int msgLen = data[1] & 0xFF;
             final byte productId = data[msgLen];
-            return productId == DreamScreenHdHandler.PRODUCT_ID || productId == DreamScreen4kHandler.PRODUCT_ID || productId == DreamScreenSoloHandler.PRODUCT_ID;
+            return productId == DreamScreenHdHandler.PRODUCT_ID || productId == DreamScreen4kHandler.PRODUCT_ID
+                    || productId == DreamScreenSoloHandler.PRODUCT_ID;
         }
         return false;
     }

--- a/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/model/DreamScreenMode.java
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/java/org/openhab/binding/dreamscreen/internal/model/DreamScreenMode.java
@@ -25,7 +25,7 @@ import org.eclipse.smarthome.core.library.types.StringType;
  */
 @NonNullByDefault
 public enum DreamScreenMode {
-    SLEEP("", 0),
+    SLEEP(MODE_SLEEP, 0),
     VIDEO(MODE_VIDEO, 1),
     MUSIC(MODE_MUSIC, 2),
     AMBIENT(MODE_AMBIENT, 3);

--- a/bundles/org.openhab.binding.dreamscreen/src/main/resources/ESH-INF/thing/channels.xml
+++ b/bundles/org.openhab.binding.dreamscreen/src/main/resources/ESH-INF/thing/channels.xml
@@ -16,6 +16,7 @@
 		<description>Switch the display mode</description>
 		<state>
 			<options>
+				<option value="sleep">Sleep</option>
 				<option value="video">Video</option>
 				<option value="music">Music</option>
 				<option value="ambient">Ambient</option>


### PR DESCRIPTION
Fix overflow error caused by optional ambient scene value in Sidekick state messages.
Add "sleep" as an optional mode, since we can't actually turn the DS off...