### PR TITLE
Make cache thread-safe and disposable

### DIFF
--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerActionPage.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerActionPage.java
@@ -51,8 +51,10 @@ public class ShellyManagerActionPage extends ShellyManagerPage {
     private final Logger logger = LoggerFactory.getLogger(ShellyManagerActionPage.class);
 
     public ShellyManagerActionPage(ConfigurationAdmin configurationAdmin, ShellyTranslationProvider translationProvider,
-            HttpClient httpClient, String localIp, int localPort, ShellyHandlerFactory handlerFactory) {
-        super(configurationAdmin, translationProvider, httpClient, localIp, localPort, handlerFactory);
+            HttpClient httpClient, String localIp, int localPort, ShellyHandlerFactory handlerFactory,
+            ShellyManagerCache<String, FwRepoEntry> firmwareRepo, ShellyManagerCache<String, FwArchList> firmwareArch) {
+        super(configurationAdmin, translationProvider, httpClient, localIp, localPort, handlerFactory, firmwareRepo,
+                firmwareArch);
     }
 
     @Override

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerImageLoader.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerImageLoader.java
@@ -41,8 +41,10 @@ public class ShellyManagerImageLoader extends ShellyManagerPage {
 
     public ShellyManagerImageLoader(ConfigurationAdmin configurationAdmin,
             ShellyTranslationProvider translationProvider, HttpClient httpClient, String localIp, int localPort,
-            ShellyHandlerFactory handlerFactory) {
-        super(configurationAdmin, translationProvider, httpClient, localIp, localPort, handlerFactory);
+            ShellyHandlerFactory handlerFactory, ShellyManagerCache<String, FwRepoEntry> firmwareRepo,
+            ShellyManagerCache<String, FwArchList> firmwareArch) {
+        super(configurationAdmin, translationProvider, httpClient, localIp, localPort, handlerFactory, firmwareRepo,
+                firmwareArch);
     }
 
     @Override

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerOtaPage.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerOtaPage.java
@@ -55,8 +55,10 @@ public class ShellyManagerOtaPage extends ShellyManagerPage {
     protected final Logger logger = LoggerFactory.getLogger(ShellyManagerOtaPage.class);
 
     public ShellyManagerOtaPage(ConfigurationAdmin configurationAdmin, ShellyTranslationProvider translationProvider,
-            HttpClient httpClient, String localIp, int localPort, ShellyHandlerFactory handlerFactory) {
-        super(configurationAdmin, translationProvider, httpClient, localIp, localPort, handlerFactory);
+            HttpClient httpClient, String localIp, int localPort, ShellyHandlerFactory handlerFactory,
+            ShellyManagerCache<String, FwRepoEntry> firmwareRepo, ShellyManagerCache<String, FwArchList> firmwareArch) {
+        super(configurationAdmin, translationProvider, httpClient, localIp, localPort, handlerFactory, firmwareRepo,
+                firmwareArch);
     }
 
     @Override

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerOverviewPage.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerOverviewPage.java
@@ -54,8 +54,10 @@ public class ShellyManagerOverviewPage extends ShellyManagerPage {
 
     public ShellyManagerOverviewPage(ConfigurationAdmin configurationAdmin,
             ShellyTranslationProvider translationProvider, HttpClient httpClient, String localIp, int localPort,
-            ShellyHandlerFactory handlerFactory) {
-        super(configurationAdmin, translationProvider, httpClient, localIp, localPort, handlerFactory);
+            ShellyHandlerFactory handlerFactory, ShellyManagerCache<String, FwRepoEntry> firmwareRepo,
+            ShellyManagerCache<String, FwArchList> firmwareArch) {
+        super(configurationAdmin, translationProvider, httpClient, localIp, localPort, handlerFactory, firmwareRepo,
+                firmwareArch);
     }
 
     @Override

--- a/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerServlet.java
+++ b/bundles/org.openhab.binding.shelly/src/main/java/org/openhab/binding/shelly/internal/manager/ShellyManagerServlet.java
@@ -13,7 +13,7 @@
 package org.openhab.binding.shelly.internal.manager;
 
 import static org.openhab.binding.shelly.internal.manager.ShellyManagerConstants.*;
-import static org.openhab.binding.shelly.internal.util.ShellyUtils.*;
+import static org.openhab.binding.shelly.internal.util.ShellyUtils.getString;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -28,15 +28,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.binding.shelly.internal.ShellyHandlerFactory;
 import org.openhab.binding.shelly.internal.api.ShellyApiException;
 import org.openhab.binding.shelly.internal.manager.ShellyManagerPage.ShellyMgrResponse;
-import org.openhab.binding.shelly.internal.provider.ShellyTranslationProvider;
-import org.openhab.core.io.net.http.HttpClientFactory;
-import org.openhab.core.net.HttpServiceUtil;
-import org.openhab.core.net.NetworkAddressService;
-import org.osgi.service.cm.ConfigurationAdmin;
-import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
@@ -65,18 +58,10 @@ public class ShellyManagerServlet extends HttpServlet {
     private final String className;
 
     @Activate
-    public ShellyManagerServlet(@Reference ConfigurationAdmin configurationAdmin,
-            @Reference NetworkAddressService networkAddressService, @Reference HttpClientFactory httpClientFactory,
-            @Reference ShellyHandlerFactory handlerFactory, @Reference ShellyTranslationProvider translationProvider,
-            ComponentContext componentContext, Map<String, Object> config) {
-        className = substringAfterLast(getClass().toString(), ".");
-        String localIp = getString(networkAddressService.getPrimaryIpv4HostAddress());
-        Integer localPort = HttpServiceUtil.getHttpServicePort(componentContext.getBundleContext());
-        this.manager = new ShellyManager(configurationAdmin, translationProvider,
-                httpClientFactory.getCommonHttpClient(), localIp, localPort, handlerFactory);
-
-        // Promote Shelly Manager usage
-        logger.info("{}", translationProvider.get("status.managerstarted", localIp, localPort.toString()));
+    public ShellyManagerServlet(@Reference ShellyManager shellyManager) {
+        className = getClass().getSimpleName();
+        this.manager = shellyManager;
+        logger.debug("{} started", className);
     }
 
     @Deactivate


### PR DESCRIPTION
@markus7017 This is my suggestion to "fix" the cache.

I've done several things:
* Dropped extending `ConcurrentHashMap` and implemented a thread-safe storage locally
* Created wrapper/record `CacheEntry` to store both the time stamp and the value in one map
* Created `dispose()` which stops the timer and clears the storage
* Made `ShellyManager` a component to make sure it's a singleton (prevent duplicate cache instances)
* Reorganized `ShellyManagerPage` and subclasses to use shared cache instances

I have done very minimal testing, since I don't have any Shelly devices to test, but I think this design will give you a "trouble free" cache.